### PR TITLE
New Drama: `lutris-wine` vs Lutris, AC patch for a certain space and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,8 @@ systemd/systemd
 
 [vcflib/vcflib/issues/206](https://github.com/vcflib/vcflib/issues/206)
 
+[VHSgunzo/lutris-wine/issues/15](https://github.com/VHSgunzo/lutris-wine/issues/15)
+
 [vimeo/player.js/issues/28](https://github.com/vimeo/player.js/issues/28)
 
 [WhisperSystems/Signal-Android/issues/127](https://github.com/WhisperSystems/Signal-Android/issues/127)


### PR DESCRIPTION
…anime game

Lutris, the Linux game launcher is having issues with a project impersonating them, by the author of Runimages. At the same time, A certain F2P gacha game's patch is being stolen and reuploaded without the authors' consent, causing concerns for DMCA takedowns for the entire project