### PR TITLE
add ksh, korn shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ bower/bower
     [archive.org](https://web.archive.org/web/20230305150614/https://desuarchive.org/g/thread/86124256),
     [ghostarchive](https://ghostarchive.org/archive/AHFsK)
 
+* korn shell - ksh
+  * original ksh kinda blew up - [ksh fallout](https://github.com/att/ast/issues/1464).
+  * original [ksh rewound](https://github.com/att/ast/issues/1466).
+  * [ksh-community](https://github.com/ksh-community) stalled.
+  * [ksh93](https://github.com/ksh93/ksh) seems to be activen now though.
+
 [fish-shell/fish-shell/pull/9512](https://github.com/fish-shell/fish-shell/pull/9512),
 [archive.ph](https://archive.ph/Nl8E7),
 [archive.org](https://web.archive.org/web/20230304112455/https://github.com/fish-shell/fish-shell/pull/9512),


### PR DESCRIPTION
`ksh`, the Korn shell blew up from the AT&T repo and the folks who were maintaining it.  I think there's an active fork working on the 1993 version.